### PR TITLE
Regenerate projects with latest Alire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 obj
 lib
 alire
+/obj/
+/lib/
+/alire/
+/config/
+/obj/
+/lib/
+/alire/
+/config/

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-obj
-lib
-alire
-/obj/
-/lib/
-/alire/
-/config/
 /obj/
 /lib/
 /alire/

--- a/alire.toml
+++ b/alire.toml
@@ -1,21 +1,10 @@
 name = "cobs"
-description = "Encoder and decoder for Consistent Overhead Byte Stuffing (COBS)"
-version = "1.0.1"
+description = "Consistent Overhead Byte Stuffing (COBS) encoder/decoder"
+version = "1.1.0-dev"
 
-licenses = ["MIT"]
+licenses = "MIT"
 authors = ["Daniel King"]
 maintainers = ["Daniel King <damaki.gh@gmail.com>"]
 maintainers-logins = ["damaki"]
 website = "https://github.com/damaki/cobs"
 tags = ["cobs", "spark", "embedded", "nostd"]
-
-[[depends-on]]
-gnat = ">=2020"
-
-[gpr-externals]
-COBS_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
-COBS_COMPILE_CHECKS = ["enabled", "disabled"]
-COBS_RUNTIME_CHECKS = ["enabled", "disabled"]
-COBS_STYLE_CHECKS = ["enabled", "disabled"]
-COBS_CONTRACTS = ["enabled", "disabled"]
-COBS_BUILD_MODE = ["debug", "optimize"]

--- a/cobs.gpr
+++ b/cobs.gpr
@@ -1,10 +1,11 @@
+with "config/cobs_config.gpr";
 project Cobs is
 
-   for Library_Name use "cobs";
-   for Library_Version use "1.0.1";
+   for Library_Name use "Cobs";
+   for Library_Version use Project'Library_Name & ".so." & Cobs_Config.Crate_Version;
 
-   for Source_Dirs use ("src");
-   for Object_Dir use "obj";
+   for Source_Dirs use ("src/", "config/");
+   for Object_Dir use "obj/" & Cobs_Config.Build_Profile;
    for Create_Missing_Dirs use "True";
    for Library_Dir use "lib";
 
@@ -13,77 +14,29 @@ project Cobs is
      external ("COBS_LIBRARY_TYPE", external ("LIBRARY_TYPE", "static"));
    for Library_Kind use Library_Type;
 
-   type Enabled_Kind is ("enabled", "disabled");
-   Compile_Checks : Enabled_Kind := External ("COBS_COMPILE_CHECKS", "enabled");
-   Runtime_Checks : Enabled_Kind := External ("COBS_RUNTIME_CHECKS", "enabled");
-   Style_Checks : Enabled_Kind := External ("COBS_STYLE_CHECKS", "enabled");
-   Contracts_Checks : Enabled_Kind := External ("COBS_CONTRACTS", "enabled");
-
-   type Build_Kind is ("debug", "optimize");
-   Build_Mode : Build_Kind := External ("COBS_BUILD_MODE", "debug");
-
-   Compile_Checks_Switches := ();
-   case Compile_Checks is
-      when "enabled" =>
-         Compile_Checks_Switches :=
-           ("-gnatwa",  -- All warnings
-            "-gnatVa",  -- All validity checks
-            "-gnatw.X", -- Disable warning may call Last_Chance_Handler
-            "-gnatwe"); -- Warnings as errors
-      when others => null;
-   end case;
-
-   Runtime_Checks_Switches := ();
-   case Runtime_Checks is
-      when "enabled" => null;
-      when others =>
-         Runtime_Checks_Switches :=
-           ("-gnatp"); -- Supress checks
-   end case;
-
-   Style_Checks_Switches := ();
-   case Style_Checks is
-      when "enabled" => null;
-         Style_Checks_Switches :=
-           ("-gnatyg",    -- GNAT Style checks
-            "-gnaty-d",   -- Disable no DOS line terminators
-            "-gnaty-I",   -- Disable check mode IN keywords
-            "-gnatyM100", -- Maximum line length
-            "-gnatyO");   -- Overriding subprograms explicitly marked as such
-      when others => null;
-   end case;
-
-   Contracts_Switches := ();
-   case Contracts_Checks is
-      when "enabled" => null;
-         Contracts_Switches :=
-           ("-gnata"); --  Enable assertions and contracts
-      when others =>
-   end case;
-
-   Compiler_Switches := ();
-   case Build_Mode is
-      when "optimize" =>
-         Compiler_Switches := ("-O3",            -- Optimization
-                               "-funroll-loops", -- Unroll loops
-                               "-gnatn");        -- Enable inlining
-      when "debug" =>
-         Compiler_Switches := ("-g",   -- Debug info
-                               "-Og"); -- No optimization
-   end case;
-
    package Compiler is
-      for Default_Switches ("Ada") use
-        Compile_Checks_Switches &
-        Compiler_Switches &
-        Runtime_Checks_Switches &
-        Style_Checks_Switches &
-        Contracts_Switches &
-        ("-gnatQ");  -- Don't quit. Generate ALI and tree files even if illegalities
+      for Default_Switches ("Ada") use Cobs_Config.Ada_Compiler_Switches;
    end Compiler;
 
    package Binder is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
    end Binder;
+
+   package Install is
+      for Artifacts (".") use ("share");
+   end Install;
+
+   package Prove is
+      for Proof_Switches ("Ada") use ("--proof=per_path",
+                                      "-j0",
+                                      "--no-global-generation",
+                                      "--no-inlining",
+                                      "--no-loop-unrolling",
+                                      "--prover=cvc4,z3,altergo",
+                                      "--timeout=60",
+                                      "--memlimit=0",
+                                      "--steps=15000",
+                                      "--report=statistics");
+   end Prove;
 
 end Cobs;

--- a/prove/.gitignore
+++ b/prove/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/bin/
+/alire/
+/config/

--- a/prove/alire.toml
+++ b/prove/alire.toml
@@ -1,0 +1,16 @@
+name = "prove"
+description = "Shiny new project"
+version = "0.1.0-dev"
+
+authors = ["Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+
+executables = ["prove"]
+
+[[depends-on]]
+gnatprove = "^11.2.3"
+cobs = "*"
+
+[[pins]]
+cobs = { path = "../" }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/bin/
+/alire/
+/config/

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -1,0 +1,16 @@
+name = "unit_tests"
+description = "Shiny new project"
+version = "0.1.0-dev"
+
+authors = ["Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+
+executables = ["unit_tests"]
+
+[[depends-on]]
+aunit = "^22.0.0"
+cobs = "*"
+
+[[pins]]
+cobs = { path = "../" }

--- a/tests/src/cobs_tests.adb
+++ b/tests/src/cobs_tests.adb
@@ -90,7 +90,8 @@ is
    --  Test the output of Encode when presented with an input consisting of
    --  no zero bytes.
    --
-   --  The output should contain additional overhead bytes, in groups of 254 bytes.
+   --  The output should contain additional overhead bytes
+   --  in groups of 254 bytes.
 
    procedure Test_Encode_No_Zeroes (T : in out Test)
    is
@@ -140,14 +141,19 @@ is
    --  Test the decoder behaviour when the frame delimiter is missing from
    --  the input buffer.
    --
-   --  The decoder should continue until the end of the input buffer is reached.
+   --  The decoder should continue until the end of the input buffer is reached
 
    procedure Test_Decode_No_Frame_Delimiter (T : in out Test)
    is
-      Input           : constant Storage_Array (1 .. 7) := (6, 1, 2, 3, 4, 5, 5);
-      Expected_Output : constant Storage_Array (1 .. 6) := (   1, 2, 3, 4, 5, 0);
-      Output          :          Storage_Array (1 .. 10);
-      Length          :          Storage_Count;
+      Input           : constant Storage_Array (1 .. 7) :=
+        (6, 1, 2, 3, 4, 5, 5);
+
+      Expected_Output : constant Storage_Array (1 .. 6) :=
+        (1, 2, 3, 4, 5, 0);
+
+      Output : Storage_Array (1 .. 10);
+      Length : Storage_Count;
+
    begin
       COBS.Decode (Input, Output, Length);
       Assert (Output (1 .. Length) = Expected_Output, "Failed output");
@@ -163,31 +169,33 @@ is
    is
       --  Short case with no replaced bytes.
       Input_1  : constant Storage_Array (1 .. 7) := (6, 1, 2, 3, 4, 5, 0);
-      Output_1 : constant Storage_Array (1 .. 5) := (   1, 2, 3, 4, 5   );
+      Output_1 : constant Storage_Array (1 .. 5) :=    (1, 2, 3, 4, 5);
 
       --  Short case with one replaced byte.
       Input_2  : constant Storage_Array (1 .. 7) := (3, 1, 2, 3, 4, 5, 0);
-      Output_2 : constant Storage_Array (1 .. 5) := (   1, 2, 0, 4, 5   );
+      Output_2 : constant Storage_Array (1 .. 5) :=    (1, 2, 0, 4, 5);
 
       --  Case where data size is 253 (no extra overhead byte)
-      Input_3 : constant Storage_Array (1 .. 255) := (1      => 254, --  Overhead byte
-                                                      255    => 0,   --  Frame delimiter
-                                                      others => 123);
+      Input_3 : constant Storage_Array (1 .. 255) :=
+        (1      => 254, --  Overhead byte
+         255    => 0,   --  Frame delimiter
+         others => 123);
       Output_3 : constant Storage_Array (1 .. 253) := (others => 123);
 
       --  Case where data size is 254 (no extra overhead byte)
-      Input_4 : constant Storage_Array (1 .. 256) := (1      => 255, --  Overhead byte
-                                                      256    => 0,   --  Frame delimiter
-                                                      others => 123);
+      Input_4 : constant Storage_Array (1 .. 256) :=
+        (1      => 255, --  Overhead byte
+         256    => 0,   --  Frame delimiter
+         others => 123);
       Output_4 : constant Storage_Array (1 .. 254) := (others => 123);
 
       --  Case where data size is 255 (1 extra overhead byte)
-      Input_5 : constant Storage_Array (1 .. 258) := (1      => 255, --  Overhead byte
-                                                      256    => 2,   --  Overhead byte
-                                                      258    => 0,   --  Frame delimiter
-                                                      others => 123);
+      Input_5 : constant Storage_Array (1 .. 258) :=
+        (1      => 255, --  Overhead byte
+         256    => 2,   --  Overhead byte
+         258    => 0,   --  Frame delimiter
+         others => 123);
       Output_5 : constant Storage_Array (1 .. 255) := (others => 123);
-
 
       Output : Storage_Array (1 .. 1000);
       Length : Storage_Count;
@@ -256,7 +264,8 @@ is
                  "Invalid length on iteration:" & Integer'Image (I));
 
          Assert (Decoded (1 .. Length) = Input,
-                 "Decoded data does not match original input on iteration:" & Integer'Image (I));
+                 "Decoded data does not match original input on iteration:" &
+                 Integer'Image (I));
       end loop;
    end Test_Encode_Decode_Loopback;
 
@@ -268,20 +277,27 @@ is
    is
       Ret : constant Access_Test_Suite := new Test_Suite;
    begin
-      Ret.Add_Test (Test_Caller.Create ("Encode an empty array",
-                                        Test_Encode_Empty'Access));
-      Ret.Add_Test (Test_Caller.Create ("Encode an array of all zeroes",
-                                        Test_Encode_All_Zeroes'Access));
-      Ret.Add_Test (Test_Caller.Create ("Encode an array of no zeroes",
-                                        Test_Encode_No_Zeroes'Access));
-      Ret.Add_Test (Test_Caller.Create ("Decode an empty frame",
-                                        Test_Decode_Empty_Frame'Access));
-      Ret.Add_Test (Test_Caller.Create ("Decode a frame with a missing frame delimiter",
-                                        Test_Decode_No_Frame_Delimiter'Access));
-      Ret.Add_Test (Test_Caller.Create ("Decode test vectors",
-                                        Test_Decode_Test_Vectors'Access));
-      Ret.Add_Test (Test_Caller.Create ("Encode/decode loopback",
-                                        Test_Encode_Decode_Loopback'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Encode an empty array",
+                             Test_Encode_Empty'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Encode an array of all zeroes",
+                             Test_Encode_All_Zeroes'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Encode an array of no zeroes",
+                             Test_Encode_No_Zeroes'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Decode an empty frame",
+                             Test_Decode_Empty_Frame'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Decode a frame with a missing frame delimiter",
+                             Test_Decode_No_Frame_Delimiter'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Decode test vectors",
+                             Test_Decode_Test_Vectors'Access));
+      Ret.Add_Test
+        (Test_Caller.Create ("Encode/decode loopback",
+                             Test_Encode_Decode_Loopback'Access));
 
       return Ret;
    end Suite;

--- a/tests/src/unit_tests.adb
+++ b/tests/src/unit_tests.adb
@@ -24,10 +24,10 @@ with AUnit.Run;
 
 with COBS_Tests;
 
-procedure Main is
+procedure Unit_Tests is
    procedure Runner is new AUnit.Run.Test_Runner (COBS_Tests.Suite);
 
    Reporter : AUnit.Reporter.Text.Text_Reporter;
 begin
    Runner (Reporter);
-end Main;
+end Unit_Tests;

--- a/tests/unit_tests.gpr
+++ b/tests/unit_tests.gpr
@@ -1,22 +1,23 @@
-with "aunit.gpr";
-
+with "config/unit_tests_config.gpr";
+with "../cobs.gpr";
 project Unit_Tests is
 
-   for Source_Dirs use ("src", "../src");
-   for Object_Dir use "obj";
-   for Main use ("main.adb");
-
-   package Builder is
-      for Switches ("ada") use ("-j0", "-g");
-   end Builder;
+   for Source_Dirs use ("src/", "config/");
+   for Object_Dir use "obj/" & Unit_Tests_Config.Build_Profile;
+   for Create_Missing_Dirs use "True";
+   for Exec_Dir use "bin";
+   for Main use ("unit_tests.adb");
 
    package Compiler is
-      for Switches ("ada") use ("-gnata", "-g", "-gnato");
+      for Default_Switches ("Ada") use Unit_Tests_Config.Ada_Compiler_Switches;
    end Compiler;
 
-   package Linker is
-      for Switches ("ada") use ("-g");
-   end Linker;
+   package Binder is
+      for Switches ("Ada") use ("-Es"); --  Symbolic traceback
+   end Binder;
+
+   package Install is
+      for Artifacts (".") use ("share");
+   end Install;
 
 end Unit_Tests;
-


### PR DESCRIPTION
* Regenerated the cobs and unit_tests projects with Alire 1.2.0.
* Use default style checks generated by Alire in validation builds:
  * Removed explicit 'in' mode.
  * Reduced line lengths to fit in 80 columns.
* Added a nested crate used to run gnatprove.