### PR TITLE
Bump working version to 1.2.0-dev

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "cobs"
 description = "Consistent Overhead Byte Stuffing (COBS) encoder/decoder"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 
 licenses = "MIT"
 authors = ["Daniel King"]


### PR DESCRIPTION
v1.1.0 has been released, so bump the version on `master` to 1.2.0-dev.