### PR TITLE
Modernise COBS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install and setup Alire package manager
-      - uses: alire-project/setup-alire@v1
+      - uses: alire-project/setup-alire@v4
         with:
-          version: 1.2.0
+          version: 2.1.0
 
       - name: Build library
         run: alr build --validation
@@ -50,7 +50,7 @@ jobs:
       - name: Proof
         run: |
           cd prove
-          alr exec -- gnatprove -P ../cobs.gpr
+          ./run-proofs.sh
         # Skip on Windows due to broken toolchain/environment which causes
         # all proof checks to fail (except initialization and termination).
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,22 @@ jobs:
       - name: Build library
         run: alr build --validation
 
-      - name: Build and run unit tests (instrumented)
-        run: |
-          cd tests
-          alr gnatcov instrument --level=stmt+mcdc --dump-trigger=atexit --projects cobs.gpr
-          alr build -- --src-subdirs=gnatcov-instr --implicit-with=gnatcov_rts_full
-          alr exec -- bin/unit_tests
-          alr gnatcov coverage --annotate=xcov --output-dir gnatcov_out --level=stmt+mcdc --projects cobs.gpr *.srctrace
-
       - name: Build and run unit tests (non-instrumented)
         run: |
           cd tests
           alr build --validation
           alr exec -- bin/unit_tests
 
+      - name: Build and run unit tests (instrumented)
+        shell: bash
+        # Skip on macos due to missing aarch64 binaries of gnatcov
+        if: matrix.os != 'macos-latest'
+        run: |
+          cd tests
+          ./coverage.sh
+
       - uses: alire-project/gnatcov-to-codecovio-action@main
+        if: matrix.os == 'ubuntu-latest'
         with:
           fail_ci_if_error: false # Don't fail the workflow if codecov.io failed
           verbose: true
@@ -51,6 +52,5 @@ jobs:
         run: |
           cd prove
           ./run-proofs.sh
-        # Skip on Windows due to broken toolchain/environment which causes
-        # all proof checks to fail (except initialization and termination).
-        if: matrix.os != 'windows-latest'
+        # There's no much value running the proofs on multiple OSes
+        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
 
       - uses: alire-project/gnatcov-to-codecovio-action@main
         if: matrix.os == 'ubuntu-latest'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: false # Don't fail the workflow if codecov.io failed
           verbose: true

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To run the proofs:
 
 ```sh
 cd prove
-alr exec -- gnatprove -P ../cobs
+./run-proofs.sh
 ```
 
 If you want to see only failed checks, then pass `--report=fail` to `gnatprove`.

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "cobs"
 description = "Consistent Overhead Byte Stuffing (COBS) encoder/decoder"
-version = "1.2.0-dev"
+version = "2.0.0-dev"
 
 licenses = "MIT"
 authors = ["Daniel King"]
@@ -8,3 +8,6 @@ maintainers = ["Daniel King <damaki.gh@gmail.com>"]
 maintainers-logins = ["damaki"]
 website = "https://github.com/damaki/cobs"
 tags = ["cobs", "spark", "embedded", "nostd"]
+
+[[depends-on]]
+gnat = ">=14"

--- a/cobs.gpr
+++ b/cobs.gpr
@@ -26,18 +26,4 @@ project Cobs is
       for Artifacts (".") use ("share");
    end Install;
 
-   package Prove is
-      for Proof_Switches ("Ada") use ("--proof=per_path",
-                                      "-j0",
-                                      "--no-global-generation",
-                                      "--no-inlining",
-                                      "--no-loop-unrolling",
-                                      "--prover=cvc4,z3,altergo",
-                                      "--timeout=60",
-                                      "--memlimit=0",
-                                      "--steps=15000",
-                                      "--report=statistics",
-                                      "--checks-as-errors");
-   end Prove;
-
 end Cobs;

--- a/prove/alire.toml
+++ b/prove/alire.toml
@@ -9,7 +9,7 @@ maintainers-logins = ["damaki"]
 executables = ["prove"]
 
 [[depends-on]]
-gnatprove = "^11.2.3"
+gnatprove = ">=14"
 cobs = "*"
 
 [[pins]]

--- a/prove/alire.toml
+++ b/prove/alire.toml
@@ -9,7 +9,7 @@ maintainers-logins = ["damaki"]
 executables = ["prove"]
 
 [[depends-on]]
-gnatprove = ">=14"
+gnatprove = "^15"
 cobs = "*"
 
 [[pins]]

--- a/prove/run-proofs.sh
+++ b/prove/run-proofs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+alr exec -- gnatprove \
+    \-P ../cobs.gpr \
+    --level=1 \
+    -j0 \
+    --checks-as-errors=on \
+    --warnings=error

--- a/src/cobs.ads
+++ b/src/cobs.ads
@@ -35,4 +35,5 @@ package COBS is new
     (Byte       => System.Storage_Elements.Storage_Element,
      Index      => System.Storage_Elements.Storage_Offset,
      Byte_Count => System.Storage_Elements.Storage_Count,
-     Byte_Array => System.Storage_Elements.Storage_Array)with Pure;
+     Byte_Array => System.Storage_Elements.Storage_Array);
+pragma Pure (COBS);

--- a/src/cobs.ads
+++ b/src/cobs.ads
@@ -29,8 +29,10 @@ with System.Storage_Elements;
 --
 --  This instantiation is only valid for systems that have a
 --  8-bit Storage_Element type.
-package COBS is new Generic_COBS
-  (Byte       => System.Storage_Elements.Storage_Element,
-   Index      => System.Storage_Elements.Storage_Offset,
-   Byte_Count => System.Storage_Elements.Storage_Count,
-   Byte_Array => System.Storage_Elements.Storage_Array) with Pure;
+
+package COBS is new
+  Generic_COBS
+    (Byte       => System.Storage_Elements.Storage_Element,
+     Index      => System.Storage_Elements.Storage_Offset,
+     Byte_Count => System.Storage_Elements.Storage_Count,
+     Byte_Array => System.Storage_Elements.Storage_Array)with Pure;

--- a/src/generic_cobs.adb
+++ b/src/generic_cobs.adb
@@ -19,17 +19,18 @@
 --  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
+
 package body Generic_COBS
-with Pure, SPARK_Mode => On
+  with Pure, SPARK_Mode => On
 is
 
    ------------
    -- Decode --
    ------------
 
-   procedure Decode (Input  :     Byte_Array;
-                     Output : out Byte_Array;
-                     Length : out Byte_Count) is
+   procedure Decode
+     (Input : Byte_Array; Output : out Byte_Array; Length : out Byte_Count)
+   is
       B          : Byte;
       Code       : Byte := Byte'Last;
       Run_Length : Byte_Count := 0;
@@ -40,9 +41,10 @@ is
       for I in 0 .. Index'Base (Input'Length - 1) loop
          pragma Loop_Invariant (Length <= Byte_Count (I));
 
-         pragma Loop_Invariant
-           (for all J in 0 .. Length - 1 =>
-              Output (Output'First + Index'Base (J))'Initialized);
+         pragma
+           Loop_Invariant
+             (for all J in 0 .. Length - 1 =>
+                Output (Output'First + Index'Base (J))'Initialized);
 
          B := Input (Input'First + I);
 
@@ -55,10 +57,10 @@ is
          else
             if Code /= Byte'Last then
                Output (Output'First + Index'Base (Length)) := Frame_Delimiter;
-               Length                                      := Length + 1;
+               Length := Length + 1;
             end if;
 
-            Code       := B;
+            Code := B;
             Run_Length := Byte_Count (Byte'Pos (B));
          end if;
 
@@ -70,61 +72,67 @@ is
    -- Encode --
    ------------
 
-   procedure Encode (Input  :     Byte_Array;
-                     Output : out Byte_Array;
-                     Length : out Byte_Count) is
+   procedure Encode
+     (Input : Byte_Array; Output : out Byte_Array; Length : out Byte_Count)
+   is
       Block_Length : Positive_Byte_Count;
       Offset       : Byte_Count;
       Remaining    : Byte_Count;
 
-      Nb_Overhead_Bytes : Positive_Byte_Count with Ghost;
+      Nb_Overhead_Bytes : Positive_Byte_Count
+      with Ghost;
 
    begin
       --  Encode first block
       Encode_Block (Input, Output, Length);
 
-      Offset            := Length - 1;
-      Remaining         := Input'Length - (Length - 1);
+      Offset := Length - 1;
+      Remaining := Input'Length - (Length - 1);
       Nb_Overhead_Bytes := 1;
 
       while Remaining > 0 loop
-         pragma Loop_Variant (Decreases => Remaining,
-                              Increases => Offset,
-                              Increases => Length,
-                              Increases => Nb_Overhead_Bytes);
+         pragma
+           Loop_Variant
+             (Decreases => Remaining,
+              Increases => Offset,
+              Increases => Length,
+              Increases => Nb_Overhead_Bytes);
 
          pragma Loop_Invariant (Offset + Remaining = Input'Length);
 
          pragma Loop_Invariant (Length = Offset + Nb_Overhead_Bytes);
 
-         pragma Loop_Invariant
-           (Nb_Overhead_Bytes < Max_Overhead_Bytes (Offset));
+         pragma
+           Loop_Invariant (Nb_Overhead_Bytes < Max_Overhead_Bytes (Offset));
 
-         pragma Loop_Invariant
-           (for all I in Output'First ..
-                         Output'First + Index'Base (Length - 1) =>
+         pragma
+           Loop_Invariant
+             (for all I in
+                Output'First .. Output'First + Index'Base (Length - 1) =>
                 Output (I)'Initialized);
 
-         pragma Loop_Invariant
-           (for all I in Output'First ..
-                         Output'First + Index'Base (Length - 1) =>
+         pragma
+           Loop_Invariant
+             (for all I in
+                Output'First .. Output'First + Index'Base (Length - 1) =>
                 Output (I) /= Frame_Delimiter);
 
          Encode_Block
-           (Input  (Input'First  + Index'Base (Offset) .. Input'Last),
+           (Input (Input'First + Index'Base (Offset) .. Input'Last),
             Output (Output'First + Index'Base (Length) .. Output'Last),
             Block_Length);
 
          Nb_Overhead_Bytes := Nb_Overhead_Bytes + 1;
 
-         Length    := Length    + Block_Length;
-         Offset    := Offset    + (Block_Length - 1);
+         Length := Length + Block_Length;
+         Offset := Offset + (Block_Length - 1);
          Remaining := Remaining - (Block_Length - 1);
       end loop;
 
-      pragma Assert
-        (for all I in Output'First ..
-                      Output'First + Index'Base (Length - 1) =>
+      pragma
+        Assert
+          (for all I in
+             Output'First .. Output'First + Index'Base (Length - 1) =>
              Output (I) /= Frame_Delimiter);
 
       Output (Output'First + Index'Base (Length)) := Frame_Delimiter;
@@ -136,18 +144,18 @@ is
    --  Encode_Block  --
    --------------------
 
-   procedure Encode_Block (Input  :     Byte_Array;
-                           Output : out Byte_Array;
-                           Length : out Byte_Count) is
+   procedure Encode_Block
+     (Input : Byte_Array; Output : out Byte_Array; Length : out Byte_Count)
+   is
       B : Byte;
 
-      Code : Positive_Byte_Count  := 1;
+      Code : Positive_Byte_Count := 1;
       --  Keeps track of the length of the current run of non-zero octets.
       --  Note that this can be 1 more than Max_Run_Size since this is
       --  1 more than the current run length (it includes the overhead octet
       --  in its count).
 
-      Code_Pos : Index   := Output'First;
+      Code_Pos : Index := Output'First;
       --  The position in 'Output' of the previous overhead/zero octet.
       --  When a run of up to 254 non-zero octets is completed (and thus the
       --  length of the run is now known), then the byte at this position in
@@ -158,32 +166,38 @@ is
 
       if Input'Length > 0 then
          for I in Byte_Count range 0 .. Input'Length - 1 loop
-            pragma Warnings
-              (Off, """Output"" may be referenced before it has a value",
-               Reason => "Initialization of Output is guaranteed via proof");
+            pragma
+              Warnings
+                (Off,
+                 """Output"" may be referenced before it has a value",
+                 Reason => "Initialization of Output is guaranteed via proof");
 
             pragma Loop_Invariant (Code in 1 .. Maximum_Run_Length + 1);
 
-            pragma Loop_Invariant
-              (Code = Length - Byte_Count (Code_Pos - Output'First));
+            pragma
+              Loop_Invariant
+                (Code = Length - Byte_Count (Code_Pos - Output'First));
 
-            pragma Loop_Invariant
-              (Code_Pos in Output'First ..
-                           Output'First + Index'Base (Length) - 1);
+            pragma
+              Loop_Invariant
+                (Code_Pos
+                 in Output'First .. Output'First + Index'Base (Length) - 1);
 
             pragma Loop_Invariant (Length = Byte_Count (I + 1));
 
             --  All bytes written so far are initialized, except the
             --  one at Code_Pos which is written later.
-            pragma Loop_Invariant
-              (for all I in Output'First ..
-                            Output'First + Index'Base (Length) - 1 =>
+            pragma
+              Loop_Invariant
+                (for all I in
+                   Output'First .. Output'First + Index'Base (Length) - 1 =>
                    (if I /= Code_Pos then Output (I)'Initialized));
 
             --  The frame delimiter is never written to the output.
-            pragma Loop_Invariant
-              (for all I in Output'First ..
-                            Output'First + Index'Base (Length) - 1 =>
+            pragma
+              Loop_Invariant
+                (for all I in
+                   Output'First .. Output'First + Index'Base (Length) - 1 =>
                    (if I /= Code_Pos then Output (I) /= Frame_Delimiter));
 
             pragma Warnings (On);
@@ -197,16 +211,16 @@ is
 
                Output (Output'First + Index'Base (Length)) := B;
 
-               Code   := Code   + 1;
+               Code := Code + 1;
                Length := Length + 1;
 
             else
                --  Replace zero byte
 
                Output (Code_Pos) := Byte'Val (Code);
-               Code_Pos          := Output'First + Index'Base (Length);
-               Length            := Length + 1;
-               Code              := 1;
+               Code_Pos := Output'First + Index'Base (Length);
+               Length := Length + 1;
+               Code := 1;
             end if;
          end loop;
       end if;

--- a/src/generic_cobs.ads
+++ b/src/generic_cobs.ads
@@ -25,55 +25,58 @@ generic
    type Index is range <>;
    type Byte_Count is range <>;
    type Byte_Array is array (Index range <>) of Byte;
-package Generic_COBS
-with Pure, SPARK_Mode => On, Always_Terminates
-is
-   pragma Compile_Time_Error (Byte'First /= 0,
-                              "Byte'First must be 0");
+package Generic_COBS with Pure, SPARK_Mode => On, Always_Terminates is
 
-   pragma Compile_Time_Error (Byte'Last <= 1,
-                              "Byte'Last must be greater than 1");
+   pragma Compile_Time_Error (Byte'First /= 0, "Byte'First must be 0");
 
-   pragma Compile_Time_Error (Byte_Count'First /= 0,
-                              "Byte_Count'First must be 0");
+   pragma
+     Compile_Time_Error (Byte'Last <= 1, "Byte'Last must be greater than 1");
 
-   pragma Compile_Time_Error
-     (Byte_Count'Pos (Byte_Count'Last) /= Index'Pos (Index'Last),
-      "Byte_Count'Last must be equal to Index'Last");
+   pragma
+     Compile_Time_Error (Byte_Count'First /= 0, "Byte_Count'First must be 0");
+
+   pragma
+     Compile_Time_Error
+       (Byte_Count'Pos (Byte_Count'Last) /= Index'Pos (Index'Last),
+        "Byte_Count'Last must be equal to Index'Last");
 
    subtype Positive_Byte_Count is Byte_Count range 1 .. Byte_Count'Last;
 
    Frame_Delimiter : constant Byte := 0;
    --  COBS uses 0 as the frame delimiter byte.
 
-   procedure Decode (Input  :     Byte_Array;
-                     Output : out Byte_Array;
-                     Length : out Byte_Count)
-     with Global => null,
+   procedure Decode
+     (Input : Byte_Array; Output : out Byte_Array; Length : out Byte_Count)
+   with
+     Global                 => null,
      Relaxed_Initialization => Output,
-     Pre => (
-             --  The bounds of the input arrays must not be large enough to
-             --  cause a Constraint_Error when reading the 'Length attribute.
-             Array_Length_Within_Bounds (Input'First, Input'Last)
-             and then Array_Length_Within_Bounds (Output'First, Output'Last)
+     Pre                    =>
+       (
+        --  The bounds of the input arrays must not be large enough to
+        --  cause a Constraint_Error when reading the 'Length attribute.
+        Array_Length_Within_Bounds (Input'First, Input'Last)
+        and then Array_Length_Within_Bounds (Output'First, Output'Last)
 
-             --  Cannot decode an empty Input array.
-             and then Input'Length > 0
+        --  Cannot decode an empty Input array.
+        and then Input'Length > 0
 
-             --  The Output array must be large enough to store all of the
-             --  decoded data.
-             and then Output'Length >= Input'Length),
+        --  The Output array must be large enough to store all of the
+        --  decoded data.
+        and then Output'Length >= Input'Length),
 
-     Post => (
-              --  The decoded length does not exceed the length of
-              --  either array parameter.
-              Length <= Output'Length
-              and then Length <= Input'Length
+     Post                   =>
+       (
+        --  The decoded length does not exceed the length of
+        --  either array parameter.
+        Length <= Output'Length
+        and then
+          Length
+          <= Input'Length
 
-              --  Only the first 'Length' bytes of the Output are initialized.
-              and then
-                (for all I in 0 .. Length - 1 =>
-                     Output (Output'First + Index'Base (I))'Initialized));
+             --  Only the first 'Length' bytes of the Output are initialized.
+        and then
+          (for all I in 0 .. Length - 1 =>
+             Output (Output'First + Index'Base (I))'Initialized));
    --  Decodes a COBS-encoded byte array.
    --
    --  @param Input The COBS encoded bytes to be decoded. This may or may not
@@ -87,45 +90,50 @@ is
    --
    --  @param Length The length of the decoded frame is written here.
 
-   procedure Encode (Input  :     Byte_Array;
-                     Output : out Byte_Array;
-                     Length : out Byte_Count)
-     with Global => null,
+   procedure Encode
+     (Input : Byte_Array; Output : out Byte_Array; Length : out Byte_Count)
+   with
+     Global                 => null,
      Relaxed_Initialization => Output,
-     Pre => (
-             --  The bounds of the input arrays must not be large enough to
-             --  cause a Constraint_Error when reading the 'Length attribute.
-             Array_Length_Within_Bounds (Input'First, Input'Last)
-             and then Array_Length_Within_Bounds (Output'First, Output'Last)
+     Pre                    =>
+       (
+        --  The bounds of the input arrays must not be large enough to
+        --  cause a Constraint_Error when reading the 'Length attribute.
+        Array_Length_Within_Bounds (Input'First, Input'Last)
+        and then Array_Length_Within_Bounds (Output'First, Output'Last)
 
-             --  The number of bytes to encode in the Input array must leave
-             --  enough headroom for COBS overhead bytes plus frame delimiter.
-             and then Input'Length <=
-               (Positive_Byte_Count'Last
-                - (Max_Overhead_Bytes (Positive_Byte_Count'Last) + 1))
+        --  The number of bytes to encode in the Input array must leave
+        --  enough headroom for COBS overhead bytes plus frame delimiter.
+        and then
+          Input'Length
+          <= (Positive_Byte_Count'Last
+              - (Max_Overhead_Bytes (Positive_Byte_Count'Last) + 1))
 
-             --  Output array must be large enough to encode the Input array
-             --  and the additional overhead bytes.
-             and then Output'Length >=
-               Input'Length + Max_Overhead_Bytes (Input'Length) + 1),
+        --  Output array must be large enough to encode the Input array
+        --  and the additional overhead bytes.
+        and then
+          Output'Length
+          >= Input'Length + Max_Overhead_Bytes (Input'Length) + 1),
 
-     Post => (
-              --  The length of the output is always bigger than the input
-              (Length in Input'Length + 1 .. Output'Length)
+     Post                   =>
+       (
+        --  The length of the output is always bigger than the input
+        (Length in Input'Length + 1 .. Output'Length)
 
-              --  Only the first 'Length' bytes of the Output are initialized.
-              and then
-                Output (Output'First ..
-                        Output'First + Index'Base (Length - 1))'Initialized
+        --  Only the first 'Length' bytes of the Output are initialized.
+        and then
+          Output
+            (Output'First
+             .. Output'First + Index'Base (Length - 1))'Initialized
 
-              --  The last byte in the output is a frame delimiter.
-              --  All other bytes before the frame delimiter are non-zero.
-              and then
-                (for all I in Output'First ..
-                              Output'First + Index'Base (Length - 1) =>
-                   (if I < Output'First + Index'Base (Length - 1)
-                    then Output (I) /= Frame_Delimiter
-                    else Output (I) = Frame_Delimiter)));
+          --  The last byte in the output is a frame delimiter.
+          --  All other bytes before the frame delimiter are non-zero.
+        and then
+          (for all I in
+             Output'First .. Output'First + Index'Base (Length - 1) =>
+             (if I < Output'First + Index'Base (Length - 1)
+              then Output (I) /= Frame_Delimiter
+              else Output (I) = Frame_Delimiter)));
    --  Encode a byte array.
    --
    --  The contents of the "Input" array are encoded and written
@@ -140,17 +148,17 @@ is
    --
    --  @param Length The length of the encoded frame is written here.
 
-   function Max_Overhead_Bytes (Input_Length : Byte_Count)
-                                return Positive_Byte_Count
-     with Global => null;
+   function Max_Overhead_Bytes
+     (Input_Length : Byte_Count) return Positive_Byte_Count
+   with Global => null;
    --  Return the maximum number of overhead bytes that are inserted into
    --  the output during COBS encoding for a given input length.
 
-   function Array_Length_Within_Bounds (First, Last : Index'Base)
-                                        return Boolean is
-     (Last < First
-      or else First > 0
-      or else Last < First + Index (Byte_Count'Last));
+   function Array_Length_Within_Bounds
+     (First, Last : Index'Base) return Boolean
+   is (Last < First
+       or else First > 0
+       or else Last < First + Index (Byte_Count'Last));
    --  Check that the length of the given range does not exceed Byte_Count'Last
    --
    --  This check is equivalent to: (Last - First) + 1 <= Byte_Count'Last
@@ -189,29 +197,35 @@ private
    --  this case is not implemented in our encoder (but is supported by
    --  the decoder).
 
-   function Max_Overhead_Bytes (Input_Length : Byte_Count)
-                                return Positive_Byte_Count is
-     ((Input_Length / Maximum_Run_Length) + 1);
+   function Max_Overhead_Bytes
+     (Input_Length : Byte_Count) return Positive_Byte_Count
+   is ((Input_Length / Maximum_Run_Length) + 1);
 
-   procedure Encode_Block (Input  :     Byte_Array;
-                           Output : out Byte_Array;
-                           Length : out Byte_Count)
-     with Inline,
-     Global => null,
+   procedure Encode_Block
+     (Input : Byte_Array; Output : out Byte_Array; Length : out Byte_Count)
+   with
+     Inline,
+     Global                 => null,
      Relaxed_Initialization => Output,
-     Pre => (Array_Length_Within_Bounds (Input'First, Input'Last)
-             and then Array_Length_Within_Bounds (Output'First, Output'Last)
-             and then Output'Length > Input'Length),
-     Post => (Length <= Input'Length + 1
-              and then (if Length < Input'Length + 1
-                        then Length >= Maximum_Run_Length + 1)
-              and then
-                Output (Output'First ..
-                        Output'First + Index'Base (Length - 1))'Initialized
-              and then
-                (for all I in Output'First ..
-                              Output'First + Index'Base (Length - 1) =>
-                    Output (I) /= Frame_Delimiter));
+     Pre                    =>
+       (Array_Length_Within_Bounds (Input'First, Input'Last)
+        and then Array_Length_Within_Bounds (Output'First, Output'Last)
+        and then Output'Length > Input'Length),
+     Post                   =>
+       (Length <= Input'Length + 1
+
+        and then
+          (if Length < Input'Length + 1 then Length >= Maximum_Run_Length + 1)
+
+        and then
+          Output
+            (Output'First
+             .. Output'First + Index'Base (Length - 1))'Initialized
+
+        and then
+          (for all I in
+             Output'First .. Output'First + Index'Base (Length - 1) =>
+             Output (I) /= Frame_Delimiter));
    --  Encodes a single block of bytes.
    --
    --  This prepends one overhead byte, then encodes as many bytes as possible

--- a/src/generic_cobs.ads
+++ b/src/generic_cobs.ads
@@ -65,18 +65,16 @@ package Generic_COBS with Pure, SPARK_Mode => On, Always_Terminates is
         and then Output'Length >= Input'Length),
 
      Post                   =>
-       (
-        --  The decoded length does not exceed the length of
-        --  either array parameter.
-        Length <= Output'Length
-        and then
-          Length
-          <= Input'Length
+       Length <= Output'Length
 
-             --  Only the first 'Length' bytes of the Output are initialized.
-        and then
-          (for all I in 0 .. Length - 1 =>
-             Output (Output'First + Index'Base (I))'Initialized));
+       and then
+         --  The decoded length does not exceed Input's length
+         Length <= Input'Length
+
+       and then
+         --  Only the first 'Length' bytes of the Output are initialized.
+         (for all I in 0 .. Length - 1 =>
+            Output (Output'First + Index'Base (I))'Initialized);
    --  Decodes a COBS-encoded byte array.
    --
    --  @param Input The COBS encoded bytes to be decoded. This may or may not

--- a/src/generic_cobs.ads
+++ b/src/generic_cobs.ads
@@ -26,7 +26,7 @@ generic
    type Byte_Count is range <>;
    type Byte_Array is array (Index range <>) of Byte;
 package Generic_COBS
-with Pure, SPARK_Mode => On
+with Pure, SPARK_Mode => On, Always_Terminates
 is
    pragma Compile_Time_Error (Byte'First /= 0,
                               "Byte'First must be 0");
@@ -73,8 +73,7 @@ is
               --  Only the first 'Length' bytes of the Output are initialized.
               and then
                 (for all I in 0 .. Length - 1 =>
-                     Output (Output'First + Index'Base (I))'Initialized)),
-     Annotate => (GNATProve, Terminating);
+                     Output (Output'First + Index'Base (I))'Initialized));
    --  Decodes a COBS-encoded byte array.
    --
    --  @param Input The COBS encoded bytes to be decoded. This may or may not
@@ -126,8 +125,7 @@ is
                               Output'First + Index'Base (Length - 1) =>
                    (if I < Output'First + Index'Base (Length - 1)
                     then Output (I) /= Frame_Delimiter
-                    else Output (I) = Frame_Delimiter))),
-     Annotate => (GNATProve, Terminating);
+                    else Output (I) = Frame_Delimiter)));
    --  Encode a byte array.
    --
    --  The contents of the "Input" array are encoded and written
@@ -213,8 +211,7 @@ private
               and then
                 (for all I in Output'First ..
                               Output'First + Index'Base (Length - 1) =>
-                    Output (I) /= Frame_Delimiter)),
-     Annotate => (GNATProve, Terminating);
+                    Output (I) /= Frame_Delimiter));
    --  Encodes a single block of bytes.
    --
    --  This prepends one overhead byte, then encodes as many bytes as possible

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -9,8 +9,8 @@ maintainers-logins = ["damaki"]
 executables = ["unit_tests"]
 
 [[depends-on]]
-aunit = "^22.0.0"
-gnatcov = "^22.0.1"
+aunit = "^25"
+gnatcov = "^22"
 cobs = "*"
 
 [[pins]]

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
+set -e
+
+alr build --profiles=*=validation
+
 alr gnatcov instrument --level=stmt+mcdc --dump-trigger=atexit --projects cobs.gpr
 
-alr build -- --src-subdirs=gnatcov-instr --implicit-with=gnatcov_rts_full
+alr build --profiles=*=validation -- --src-subdirs=gnatcov-instr --implicit-with=gnatcov_rts_full
 
 alr exec -- bin/unit_tests
 

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -16,3 +16,10 @@ alr gnatcov coverage \
     --level=stmt+mcdc \
     --projects cobs.gpr \
     *.srctrace
+
+alr gnatcov coverage \
+    --annotate=xcov+ \
+    --output-dir gnatcov_out \
+    --level=stmt+mcdc \
+    --projects cobs.gpr \
+    *.srctrace


### PR DESCRIPTION
Various maintenance tasks on the library:
* Update toolchain versions used
* Minor script improvements
* Replace deprecated `Terminating` annotation with `Always_Terminates` (breaking change, new minimum GNAT/GNATprove FSF version is now 14).